### PR TITLE
Adds initial unit tests

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/valyala/fastjson v1.6.4 h1:uAUNq9Z6ymTgGhcm0UynUAB6tlbakBrz6CQFax3BXVQ=
+github.com/valyala/fastjson v1.6.4/go.mod h1:CLCAqky6SMuOcxStkYQvblddUtoRxhYMGLrsQns1aXY=

--- a/spec/extension.go
+++ b/spec/extension.go
@@ -1,6 +1,18 @@
 package spec
 
-import "github.com/valyala/fastjson"
+import (
+	"strings"
+
+	"github.com/valyala/fastjson"
+)
 
 // Extensions defines a map of keys prefixed with 'x-' and any type of value
 type Extensions map[string]*fastjson.Value
+
+func (exts Extensions) marshalExtensions(val *fastjson.Value) {
+	for k, v := range exts {
+		if strings.HasPrefix(k, "x-") {
+			val.Set(k, v)
+		}
+	}
+}

--- a/spec/parser.go
+++ b/spec/parser.go
@@ -11,6 +11,8 @@ import (
 	"github.com/valyala/fastjson"
 )
 
+var arenaPool fastjson.ArenaPool
+
 // Parser handles the parsing and validation of a swagger spec
 type Parser struct {
 	raw                []byte
@@ -34,7 +36,7 @@ func (p *Parser) HasError() bool {
 	if p == nil {
 		return false
 	}
-	return len(p.errorsByLocation) == 0
+	return len(p.errorsByLocation) > 0
 }
 
 func (p *Parser) Parse() (*Swagger, error) {

--- a/spec/swagger.go
+++ b/spec/swagger.go
@@ -171,6 +171,45 @@ func NewExternalDocumentation() *ExternalDocumentation {
 	}
 }
 
+func (ed *ExternalDocumentation) marshal(a *fastjson.Arena) *fastjson.Value {
+	val := a.NewObject()
+	if ed.Description != "" {
+		val.Set("description", a.NewString(ed.Description))
+	}
+	if ed.URL != "" {
+		val.Set("url", a.NewString(ed.URL))
+	}
+	ed.marshalExtensions(val)
+	return val
+}
+
+func (ed *ExternalDocumentation) String() string {
+	if ed == nil {
+		return ""
+	}
+	a := arenaPool.Get()
+	defer func() {
+		a.Reset()
+		arenaPool.Put(a)
+	}()
+	val := ed.marshal(a)
+	return string(val.MarshalTo(nil))
+}
+
+func (ed *ExternalDocumentation) description() string {
+	if ed != nil {
+		return ed.Description
+	}
+	return ""
+}
+
+func (ed *ExternalDocumentation) url() string {
+	if ed != nil {
+		return ed.URL
+	}
+	return ""
+}
+
 // parseExternalDocumentation will attempt to parse an ExternalDocumentation from the source swagger .externalDocumentation JSON values
 func parseExternalDocumentation(edVal *fastjson.Value, parser *Parser) *ExternalDocumentation {
 	// first be sure to capture and reset our parser's location

--- a/spec/tag_test.go
+++ b/spec/tag_test.go
@@ -45,7 +45,7 @@ func Test_parseTag(t *testing.T) {
 	for should, tt := range tests {
 		parser := NewParser(nil)
 		parser.currentLoc = tt.location
-		tagVal := newTagJSON(arena, tt.expectedTag)
+		tagVal := tt.expectedTag.marshal(&arena)
 		t.Run(should, func(t *testing.T) {
 			got := parseTag(tagVal, parser)
 			if tt.expectedErr != nil {
@@ -84,29 +84,4 @@ func tagsEqual(t1, t2 *Tag) bool {
 		}
 	}
 	return true
-}
-
-func newTagJSON(a fastjson.Arena, tag *Tag) *fastjson.Value {
-	if tag == nil {
-		return nil
-	}
-	tagVal := a.NewObject()
-	if tag.Name != "" {
-		tagVal.Set("name", a.NewString(tag.Name))
-	}
-	if tag.Description != "" {
-		tagVal.Set("description", a.NewString(tag.Description))
-	}
-	tag.marshalExtensions(tagVal)
-	if tag.ExternalDocumentation != nil {
-		extDocs := a.NewObject()
-		if tag.ExternalDocumentation.Description != "" {
-			extDocs.Set("description", a.NewString(tag.ExternalDocumentation.Description))
-		}
-		if tag.ExternalDocumentation.URL != "" {
-			extDocs.Set("url", a.NewString(tag.ExternalDocumentation.URL))
-		}
-		tagVal.Set("externalDocs", extDocs)
-	}
-	return tagVal
 }

--- a/spec/tag_test.go
+++ b/spec/tag_test.go
@@ -1,0 +1,112 @@
+package spec
+
+import (
+	"testing"
+
+	"github.com/valyala/fastjson"
+)
+
+func Test_parseTag(t *testing.T) {
+	var arena fastjson.Arena
+	defer arena.Reset()
+
+	type testCase struct {
+		location    string
+		expectedTag *Tag
+		expectedErr error
+	}
+	tests := map[string]testCase{
+		"valid tag should return valid result without error": {
+			location: ".tags[0]",
+			expectedTag: &Tag{
+				Name:        "TestTag",
+				Description: "just a test tag",
+			},
+		},
+		"valid tag with externalDocs should return valid result without error": {
+			location: ".tags[0]",
+			expectedTag: &Tag{
+				Name:        "TestTag",
+				Description: "just a test tag",
+				ExternalDocumentation: func() *ExternalDocumentation {
+					ed := NewExternalDocumentation()
+					ed.URL = "https://example.com/docs"
+					ed.Description = "example external docs"
+					return ed
+				}(),
+				Extensions: func() Extensions {
+					ext := make(Extensions, 1)
+					ext["x-robbie"] = arena.NewString("poop!")
+					return ext
+				}(),
+			},
+		},
+	}
+	for should, tt := range tests {
+		parser := NewParser(nil)
+		parser.currentLoc = tt.location
+		tagVal := newTagJSON(arena, tt.expectedTag)
+		t.Run(should, func(t *testing.T) {
+			got := parseTag(tagVal, parser)
+			if tt.expectedErr != nil {
+				if err := parser.Err(); err == nil {
+					t.Errorf("error was nil but we expected: %s", tt.expectedErr)
+				}
+			} else if !tagsEqual(got, tt.expectedTag) {
+				t.Errorf("parseTag() = %v, want %v", got, tt.expectedTag)
+			}
+			t.Log(got.String())
+		})
+	}
+}
+
+func tagsEqual(t1, t2 *Tag) bool {
+	if t1.Name != t2.Name {
+		return false
+	}
+	if t1.Description != t2.Description {
+		return false
+	}
+	if t1.ExternalDocumentation.url() != t2.ExternalDocumentation.url() {
+		return false
+	}
+	if t1.ExternalDocumentation.description() != t2.ExternalDocumentation.description() {
+		return false
+	}
+	if len(t1.Extensions) != len(t2.Extensions) {
+		return false
+	}
+	if len(t1.Extensions) > 0 {
+		for k1, v1 := range t1.Extensions {
+			if v1 != t2.Extensions[k1] {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func newTagJSON(a fastjson.Arena, tag *Tag) *fastjson.Value {
+	if tag == nil {
+		return nil
+	}
+	tagVal := a.NewObject()
+	if tag.Name != "" {
+		tagVal.Set("name", a.NewString(tag.Name))
+	}
+	if tag.Description != "" {
+		tagVal.Set("description", a.NewString(tag.Description))
+	}
+	tag.marshalExtensions(tagVal)
+	if tag.ExternalDocumentation != nil {
+		extDocs := a.NewObject()
+		if tag.ExternalDocumentation.Description != "" {
+			extDocs.Set("description", a.NewString(tag.ExternalDocumentation.Description))
+		}
+		if tag.ExternalDocumentation.URL != "" {
+			extDocs.Set("url", a.NewString(tag.ExternalDocumentation.URL))
+		}
+		tagVal.Set("externalDocs", extDocs)
+	}
+	return tagVal
+}


### PR DESCRIPTION
This also corrects the `spec.Swagger` object structure to represent its security as an _array_ of `spec.SecurityRequirements` instead of a single one.